### PR TITLE
DTPORTAL-16979 Prevent inappropriate transcoding

### DIFF
--- a/channels/chan_sip.c
+++ b/channels/chan_sip.c
@@ -13695,10 +13695,8 @@ static enum sip_result add_sdp(struct sip_request *resp, struct sip_pvt *p, int 
 			ast_str_append(&a_audio, 0, "a=maxptime:%d\r\n", max_audio_packet_size);
 		}
 
-		if (!ast_test_flag(&p->flags[0], SIP_OUTGOING)) {
-			ast_debug(1, "Setting framing on incoming call: %u\n", min_audio_packet_size);
-			ast_rtp_codecs_set_framing(ast_rtp_instance_get_codecs(p->rtp), min_audio_packet_size);
-		}
+		ast_debug(1, "Setting framing on %s call: %u\n", ast_test_flag(&p->flags[0], SIP_OUTGOING) ? "outgoing" : "incoming", min_audio_packet_size);
+		ast_rtp_codecs_set_framing(ast_rtp_instance_get_codecs(p->rtp), min_audio_packet_size);
 
 		if (!doing_directmedia) {
 			if (ast_test_flag(&p->flags[2], SIP_PAGE3_ICE_SUPPORT)) {


### PR DESCRIPTION
Fix corrupted audio on outbound calls by assuring that we set packetization time.  Addresses unispeech/asterisk-unimrcp#37

This fix follows 869ef2a8ee4e4df271227d6b9b48470e44ad4831's partial fix to add_sdp().  In that previous fix, only inbound legs were fixed.  This PR ensure that that fix applies to outbound legs as well.

Context:
* [UniMRCP has always written packets of size 10ms.](https://github.com/unispeech/unimrcp/blob/unimrcp-1.6.0/libs/mpf/include/mpf_codec_descriptor.h#L32)
* [Previously,](https://github.com/asterisk/asterisk/blob/1.8.13.0/res/res_rtp_asterisk.c#L1393-L1394) Asterisk would correct this behavior with its RTP "Smoother", regulating outgoing packets to be of the size that has been negotiated - in our case 20ms.
* [The RTP "Smoother" is not initialized if the RTP Instance lacks a packetization time, or `framing_ms`](https://github.com/asterisk/asterisk/blob/13.19.1/res/res_rtp_asterisk.c#L4176-L4177). (This shouldn't ever occur... but it does under Asterisk 13 for some still unknown reason).
* A quick-fix was added in 869ef2a8ee4e4df271227d6b9b48470e44ad4831, but was only ever applied to heal inbound calls and not outbound ones.
* This PR broadens that quick-fix to heal outbound calls as well.